### PR TITLE
Fix `MutableConstants` check error on body-less procs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [0.2.4] - Unreleased
+
+- The mutable-constants check no longer crashes with a
+  `NoMethodError` on a proc constant built from a block
+  argument (e.g. `TRUE_NODE = lambda(&:true_type?)`. [@viralpraxis](https://github.com/viralpraxis)
+- A proc constant whose block arrives as `&expr` gets no
+  `Ractor.make_shareable` autofix. There is no body for the
+  capture scanner to read, so the wrap cannot be shown safe. [@viralpraxis](https://github.com/viralpraxis)
+
 ## [0.2.3] - 2026-08-22
 
 - Fix knowledge base refreshed from the latest fixes on Rails

--- a/lib/audition/static/checks/mutable_constants.rb
+++ b/lib/audition/static/checks/mutable_constants.rb
@@ -175,6 +175,7 @@ module Audition
             # a class or module body get the wrap.
             body = proc_body(value)
             wrappable = fix_ok && namespaced?(node) &&
+              !opaque_proc?(value) &&
               (body.nil? ||
                 RactorIsolation::CaptureScanner
                   .scan(body).empty?)
@@ -199,8 +200,14 @@ module Audition
         def proc_body(value)
           case value
           when Prism::LambdaNode then value.body
-          when Prism::CallNode then value.block&.body
+          when Prism::CallNode
+            block = value.block
+            block.body if block.is_a?(Prism::BlockNode)
           end
+        end
+
+        def opaque_proc?(value)
+          value.is_a?(Prism::CallNode) && value.block.is_a?(Prism::BlockArgumentNode)
         end
 
         def namespaced?(node)

--- a/spec/audition/static/checks/mutable_constants_spec.rb
+++ b/spec/audition/static/checks/mutable_constants_spec.rb
@@ -142,6 +142,34 @@ RSpec.describe Audition::Static::Checks::MutableConstants do
     )
   end
 
+  it "handles procs built from a block argument" do
+    findings = findings_for(<<~RUBY)
+      module Matchers
+        TRUE_NODE = lambda(&:true_type?)
+        SHOUT = proc(&:upcase)
+        WRAPPED = Proc.new(&handler)
+      end
+    RUBY
+
+    expect(findings.size).to eq(3)
+    expect(findings).to all(
+      have_attributes(check: "mutable-constants")
+    )
+  end
+
+  it "withholds proc wraps when the block comes from elsewhere" do
+    findings = findings_for(<<~RUBY)
+      module Matchers
+        OPAQUE = lambda(&handler)
+        CLEAN = lambda { |msg| msg.to_s }
+      end
+    RUBY
+
+    by_name = findings.to_h { |f| [f.message[/[A-Z]+/], f] }
+    expect(by_name["OPAQUE"].autofix).to be_nil
+    expect(by_name["CLEAN"].autofix).not_to be_nil
+  end
+
   it "gates proc wraps on capture-free lambdas in a namespace" do
     findings = findings_for(<<~RUBY)
       TOP = ->(x) { x.to_s }


### PR DESCRIPTION
```shell
$ echo 'A = lambda(&:itself)' | ruby -raudition -e 'Audition::Static::Analyzer.new.analyze_source($stdin.read, path: "/dev/stdin")'
gems/4.0.0/gems/audition-0.2.3/lib/audition/static/checks/mutable_constants.rb:202:in 'Audition::Static::Checks::MutableConstants#proc_body': undefined method 'body' for an instance of Prism::BlockArgumentNode (NoMethodError)
```